### PR TITLE
Fix multi icon mask threshold

### DIFF
--- a/src/pingico.ts
+++ b/src/pingico.ts
@@ -140,7 +140,7 @@ async function pngToIco(png: Uint8Array): Promise<IcoData> {
   const maskRow = Math.ceil(width / 32) * 4;
   const andMask = new Uint8Array(maskRow * height);
   const strict = width >= 256;
-  const maskThreshold = strict ? 10 : 12;
+  const maskThreshold = 10;
   for (let y = 0; y < height; y++) {
     for (let x = 0; x < width; x++) {
       const a = image[(y * width + x) * 4 + 3];
@@ -164,7 +164,7 @@ async function pngToIco(png: Uint8Array): Promise<IcoData> {
       const src = (y * width + x) * 4;
       const dst = ((height - 1 - y) * width + x) * 4;
       const a = image[src + 3];
-      if (!strict && a < 12) {
+      if (!strict && a < maskThreshold) {
         pixelData[dst] = 0;
         pixelData[dst + 1] = 0;
         pixelData[dst + 2] = 0;


### PR DESCRIPTION
## Summary
- adjust mask transparency threshold
- use the threshold consistently when blanking pixel colors

## Testing
- `deno test -A`

------
https://chatgpt.com/codex/tasks/task_e_687383d32164832c9d48d336d71d77f5